### PR TITLE
Fix naming inconsistencies for cities data

### DIFF
--- a/03-Loading-Data/readme.md
+++ b/03-Loading-Data/readme.md
@@ -9,7 +9,7 @@ You're probably already familiar with JSON, let's take a look at CSV. CSV stands
 Here is a sample CSV file: 
 
 ```
-"name","population","country","x","y"
+"label","population","country","x","y"
 "San Francisco",874961,"USA",122,-37
 "Fresno",525010,"USA",119,-36
 "Lahore",11126285,"Pakistan",74,31
@@ -25,7 +25,7 @@ Each row is one record.
 Take a look at the first row, the first row is special: 
 
 ```
-"name","population","country","x","y"
+"label","population","country","x","y"
 ```
 
 This row defines the fields for all of the other rows. Each field is separated by a comma. The first line names the values in each of the following rows. 

--- a/09-bars/readme.md
+++ b/09-bars/readme.md
@@ -30,18 +30,18 @@ In your script load this dataset using your favorite method.
 
 ## Drawing Bars
 
-At this point, you should have your data loaded. The data should be an array of cities with names, populations, and countries. It should look something like this: 
+At this point, you should have your data loaded. The data should be an array of cities with labels, populations, and countries. It should look something like this: 
 
 ```JS
 [
-  {name: "San Francisco", population: "874961", country: "USA", x: "122", y: "-37"}
-  {name: "Fresno", population: "525010", country: "USA", x: "119", y: "-36"}
-  {name: "Lahore", population: "11126285", country: "Pakistan", x: "74", y: "31"}
-  {name: "Karachi", population: "14910352", country: "Pakistan", x: "67", y: "24"}
-  {name: "Rome", population: "4342212", country: "Italy", x: "12", y: "41"}
-  {name: "Naples", population: "967069", country: "Italy", x: "14", y: "40"}
-  {name: "Rio", population: "6748000", country: "Brazil", x: "-43", y: "-22"}
-  {name: "Sao Paolo", population: "12300000", country: "Brazil", x: "-46", y: "-23"}
+  {label: "San Francisco", population: "874961", country: "USA", x: "122", y: "-37"}
+  {label: "Fresno", population: "525010", country: "USA", x: "119", y: "-36"}
+  {label: "Lahore", population: "11126285", country: "Pakistan", x: "74", y: "31"}
+  {label: "Karachi", population: "14910352", country: "Pakistan", x: "67", y: "24"}
+  {label: "Rome", population: "4342212", country: "Italy", x: "12", y: "41"}
+  {label: "Naples", population: "967069", country: "Italy", x: "14", y: "40"}
+  {label: "Rio", population: "6748000", country: "Brazil", x: "-43", y: "-22"}
+  {label: "Sao Paolo", population: "12300000", country: "Brazil", x: "-46", y: "-23"}
 ]
 ```
 

--- a/13-Pie-Charts/readme.md
+++ b/13-Pie-Charts/readme.md
@@ -46,7 +46,7 @@ handleData()
 The cities data looks like this: 
 
 ```CSV
-"name","population","country","x","y"
+"label","population","country","x","y"
 "San Francisco",874961,"USA",122,-37
 "Fresno",525010,"USA",119,-36
 "Lahore",11126285,"Pakistan",74,31
@@ -56,18 +56,18 @@ After importing it should be arranged like this. Check it for yourself by loggin
 
 ```JS
 [
-  {name: "San Francisco", population: "874961", country: "USA", x: "122", y: "-37"},
-  {name: "Fresno", population: "525010", country: "USA", x: "119", y: "-36"},
-  {name: "Lahore", population: "11126285", country: "Pakistan", x: "74", y: "31"},
-  {name: "Karachi", population: "14910352", country: "Pakistan", x: "67", y: "24"},
-  {name: "Rome", population: "4342212", country: "Italy", x: "12", y: "41"},
+  {label: "San Francisco", population: "874961", country: "USA", x: "122", y: "-37"},
+  {label: "Fresno", population: "525010", country: "USA", x: "119", y: "-36"},
+  {label: "Lahore", population: "11126285", country: "Pakistan", x: "74", y: "31"},
+  {label: "Karachi", population: "14910352", country: "Pakistan", x: "67", y: "24"},
+  {label: "Rome", population: "4342212", country: "Italy", x: "12", y: "41"},
   ...
 ]
 ```
 
 This is an array of objects with properties of:
 
-- name
+- label
 - population
 - country
 - x
@@ -271,7 +271,7 @@ labels
   .data(data)
   .enter()
   .append('text')
-  .text(d => d.name)
+  .text(d => d.label)
   .attr('x', 20)
   .attr('y', (d, i) => (i * 20) + 20)
 ```
@@ -342,7 +342,7 @@ rLabels
   .data(data)
   .enter()
   .append('text')
-  .text(d => d.name)
+  .text(d => d.label)
   // Place labels around circle ?
   .attr("transform", (d, i) => `translate(${arcLabels.centroid(arcData[i])})`)
   .attr('text-anchor', 'middle')


### PR DESCRIPTION
Multiple parts of the D3 tutorial use the cities.csv file. There are inconsistencies in the naming of the first column of data (files switch between `label` or `name`). 

This PR aims to fix this by ensuring that `label` is used consistently throughout. 